### PR TITLE
Add single-page cat breed explorer website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cat Breed Explorer</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrapper">
+      <h1>Cat Breed Explorer</h1>
+      <p>Tap a cat to learn what makes each breed unique.</p>
+    </div>
+  </header>
+
+  <main class="wrapper">
+    <section class="gallery" aria-label="Cat breeds">
+      <button class="breed-card" data-breed="persian">
+        <img src="https://images.unsplash.com/photo-1552410260-0fdde1b8105f?auto=format&fit=crop&w=600&q=80" alt="Fluffy Persian cat" loading="lazy">
+        <span>Persian</span>
+      </button>
+      <button class="breed-card" data-breed="siamese">
+        <img src="https://images.unsplash.com/photo-1508674861872-3d7abdb11b83?auto=format&fit=crop&w=600&q=80" alt="Blue-eyed Siamese cat" loading="lazy">
+        <span>Siamese</span>
+      </button>
+      <button class="breed-card" data-breed="maine-coon">
+        <img src="https://images.unsplash.com/photo-1548199973-03cce0bbc87b?auto=format&fit=crop&w=600&q=80" alt="Maine Coon cat relaxing" loading="lazy">
+        <span>Maine Coon</span>
+      </button>
+      <button class="breed-card" data-breed="bengal">
+        <img src="https://images.unsplash.com/photo-1619983081650-92ada9552050?auto=format&fit=crop&w=600&q=80" alt="Bengal cat with spotted coat" loading="lazy">
+        <span>Bengal</span>
+      </button>
+      <button class="breed-card" data-breed="sphynx">
+        <img src="https://images.unsplash.com/photo-1581783898377-2d0a8d63a4eb?auto=format&fit=crop&w=600&q=80" alt="Hairless Sphynx cat" loading="lazy">
+        <span>Sphynx</span>
+      </button>
+      <button class="breed-card" data-breed="ragdoll">
+        <img src="https://images.unsplash.com/photo-1533738363-b7f9aef128ce?auto=format&fit=crop&w=600&q=80" alt="Ragdoll cat with blue eyes" loading="lazy">
+        <span>Ragdoll</span>
+      </button>
+    </section>
+
+    <section class="breed-info" aria-live="polite">
+      <div class="info-panel">
+        <h2 id="breed-name">Select a cat breed</h2>
+        <p id="breed-description">Click on any of the breeds to see their origin, personality, grooming needs, and more.</p>
+        <dl id="breed-details" class="details-list" hidden>
+          <div>
+            <dt>Origin</dt>
+            <dd id="detail-origin"></dd>
+          </div>
+          <div>
+            <dt>Personality</dt>
+            <dd id="detail-personality"></dd>
+          </div>
+          <div>
+            <dt>Coat</dt>
+            <dd id="detail-coat"></dd>
+          </div>
+          <div>
+            <dt>Care Tip</dt>
+            <dd id="detail-tip"></dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="wrapper">
+      <p>Images courtesy of photographers on Unsplash. Information compiled from popular cat breed resources.</p>
+    </div>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,99 @@
+const breedData = {
+  'persian': {
+    name: 'Persian',
+    description: 'Persian cats are gentle, affectionate companions that love a calm environment and lots of pampering.',
+    origin: 'Historical Persia (modern-day Iran)',
+    personality: 'Sweet, quiet, and happy to lounge with their people.',
+    coat: 'Long, plush double coat in a wide variety of colors.',
+    tip: 'Daily brushing keeps their coat tangle-free and reduces hairballs.'
+  },
+  'siamese': {
+    name: 'Siamese',
+    description: 'Siamese cats are vocal extroverts that thrive on attention and interactive play sessions.',
+    origin: 'Thailand (formerly Siam)',
+    personality: 'Curious, talkative, and devoted to their favorite humans.',
+    coat: 'Short, sleek coat with striking color-point pattern and blue eyes.',
+    tip: 'Provide puzzle toys or training games to channel their intelligence.'
+  },
+  'maine-coon': {
+    name: 'Maine Coon',
+    description: 'Known as gentle giants, Maine Coons combine impressive size with a friendly, dog-like attitude.',
+    origin: 'United States (Maine)',
+    personality: 'Sociable, confident, and typically great with families.',
+    coat: 'Long, shaggy coat with a bushy tail built for cold climates.',
+    tip: 'Weekly combing and a tall cat tree help them stay groomed and exercised.'
+  },
+  'bengal': {
+    name: 'Bengal',
+    description: 'Bengals bring wildcat looks into the living room with their rosetted coats and athletic build.',
+    origin: 'United States (hybrid of Asian leopard cat and domestic cats)',
+    personality: 'Energetic, adventurous, and always ready to climb.',
+    coat: 'Short, glittering coat with dramatic marbled or spotted patterns.',
+    tip: 'Offer vertical spaces and regular playtime to match their energy.'
+  },
+  'sphynx': {
+    name: 'Sphynx',
+    description: 'The Sphynx may be hairless, but they make up for it with warmth, affection, and playful antics.',
+    origin: 'Canada',
+    personality: 'Friendly, extroverted, and loves to cuddle for warmth.',
+    coat: 'Soft down or no coat; skin feels like warm suede.',
+    tip: 'Schedule gentle baths to remove oils and keep their skin healthy.'
+  },
+  'ragdoll': {
+    name: 'Ragdoll',
+    description: 'Ragdolls are relaxed lap cats that often flop into your arms like a plush toy.',
+    origin: 'United States',
+    personality: 'Mellow, affectionate, and typically easygoing with kids and pets.',
+    coat: 'Semi-long silky coat with pointed coloration and bright blue eyes.',
+    tip: 'Brush a few times each week and provide cozy lounging spots they can claim.'
+  }
+};
+
+const cards = document.querySelectorAll('.breed-card');
+const nameEl = document.getElementById('breed-name');
+const descriptionEl = document.getElementById('breed-description');
+const detailsList = document.getElementById('breed-details');
+const originEl = document.getElementById('detail-origin');
+const personalityEl = document.getElementById('detail-personality');
+const coatEl = document.getElementById('detail-coat');
+const tipEl = document.getElementById('detail-tip');
+
+let activeCard = null;
+
+function setActiveCard(card) {
+  if (activeCard) {
+    activeCard.classList.remove('is-active');
+  }
+  activeCard = card;
+  card.classList.add('is-active');
+}
+
+function showBreed(key) {
+  const breed = breedData[key];
+
+  if (!breed) {
+    return;
+  }
+
+  nameEl.textContent = breed.name;
+  descriptionEl.textContent = breed.description;
+  originEl.textContent = breed.origin;
+  personalityEl.textContent = breed.personality;
+  coatEl.textContent = breed.coat;
+  tipEl.textContent = breed.tip;
+  detailsList.hidden = false;
+}
+
+cards.forEach((card) => {
+  card.addEventListener('click', () => {
+    const key = card.dataset.breed;
+    showBreed(key);
+    setActiveCard(card);
+  });
+});
+
+const defaultCard = document.querySelector('.breed-card');
+if (defaultCard) {
+  showBreed(defaultCard.dataset.breed);
+  setActiveCard(defaultCard);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,217 @@
+:root {
+  color-scheme: light;
+  --bg: #f3f4f6;
+  --card-bg: #ffffff;
+  --accent: #f97316;
+  --accent-dark: #ea580c;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Nunito', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, #fef3c7, #f3f4f6);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.wrapper {
+  width: min(1100px, 90vw);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.site-header {
+  padding: 3rem 0 2rem;
+  text-align: center;
+}
+
+.site-header h1 {
+  font-size: clamp(2rem, 6vw, 3.5rem);
+  margin-bottom: 0.5rem;
+}
+
+.site-header p {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--muted);
+}
+
+main {
+  display: grid;
+  gap: 2.5rem;
+  padding-bottom: 3rem;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.25rem;
+}
+
+.breed-card {
+  border: 0;
+  border-radius: 18px;
+  overflow: hidden;
+  background: var(--card-bg);
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  padding: 0;
+  text-align: center;
+  transition: transform 150ms ease, box-shadow 150ms ease, outline 150ms ease;
+  position: relative;
+  isolation: isolate;
+}
+
+.breed-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(17, 24, 39, 0.45), rgba(17, 24, 39, 0));
+  opacity: 0;
+  transition: opacity 150ms ease;
+  z-index: 0;
+}
+
+.breed-card img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.breed-card span {
+  position: absolute;
+  inset: auto 0 1rem 0;
+  z-index: 1;
+  color: #f9fafb;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  text-shadow: 0 6px 20px rgba(0, 0, 0, 0.7);
+}
+
+.breed-card:hover,
+.breed-card:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.15);
+}
+
+.breed-card:hover::after,
+.breed-card:focus-visible::after,
+.breed-card.is-active::after {
+  opacity: 1;
+}
+
+.breed-card.is-active {
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.breed-info {
+  display: flex;
+  justify-content: center;
+}
+
+.info-panel {
+  width: min(720px, 100%);
+  background: var(--card-bg);
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.info-panel::before {
+  content: '';
+  position: absolute;
+  top: -120px;
+  right: -120px;
+  width: 240px;
+  height: 240px;
+  background: radial-gradient(circle, rgba(249, 115, 22, 0.3), transparent 60%);
+  z-index: 0;
+}
+
+.info-panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.info-panel h2 {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  margin: 0 0 0.75rem;
+}
+
+.info-panel p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+.details-list {
+  margin-top: 1.75rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.details-list div {
+  background: rgba(249, 250, 251, 0.8);
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+dt {
+  margin: 0 0 0.35rem;
+  font-weight: 700;
+  color: var(--accent-dark);
+}
+
+dd {
+  margin: 0;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.site-footer {
+  margin-top: auto;
+  padding: 2.5rem 0;
+  color: var(--muted);
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+@media (min-width: 960px) {
+  main {
+    grid-template-columns: 1.05fr 1fr;
+    align-items: start;
+  }
+
+  .gallery {
+    position: sticky;
+    top: 2rem;
+    align-self: start;
+  }
+}
+
+@media (max-width: 640px) {
+  .breed-card img {
+    height: 150px;
+  }
+
+  .info-panel {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add an index page showcasing multiple cat breeds with imagery
- apply responsive styling for the gallery and information panel
- implement JavaScript interactions so clicking a breed reveals its key facts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd076a21088328826e85a8f7eeafe9